### PR TITLE
Change lsb-release ID for Pop!_OS

### DIFF
--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -75,7 +75,7 @@ impl Vendor {
                 "centos" | "redhat" | "rhel" => yum::init(),
                 "fedora" => dnf::init(),
                 "alpine" => apk::init(),
-                "debian" | "ubuntu" | "pop-os" | "deepin" | "elementary OS" | "kali"
+                "debian" | "ubuntu" | "pop" | "deepin" | "elementary OS" | "kali"
                 | "linuxmint" => apt::init(),
                 _ => {
                     return Err(UptError::NotSupportOS);


### PR DESCRIPTION
In the latest release of Pop!_OS ("Groovy Gorilla", 20.10) `DISTRIB_ID=` is now set to `pop` and not `pop-os`. Because of this *upt* gives the error `Your os is not supported currently`.