### PR TITLE
Support AOSC OS

### DIFF
--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -76,7 +76,7 @@ impl Vendor {
                 "fedora" => dnf::init(),
                 "alpine" => apk::init(),
                 "debian" | "ubuntu" | "pop-os" | "deepin" | "elementary OS" | "kali"
-                | "linuxmint" => apt::init(),
+                | "linuxmint" | "aosc" => apt::init(),
                 _ => {
                     return Err(UptError::NotSupportOS);
                 }


### PR DESCRIPTION
AOSC OS is a APT/DPKG distro (https://wiki.aosc.io/aosc-os/is-aosc-os-right-for-me/)