### PR TITLE
feat: show upt version/tools in help txt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt;
 pub enum UptError {
     NoVendor(String),
     NoTask,
-    NotFoundTool,
+    NoDetectVendor,
     InvalidAction(String),
     InvalidArgs(String),
     DisplyHelp(String),
@@ -17,11 +17,11 @@ impl fmt::Display for UptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use UptError::*;
         match self {
-            NoVendor(v) => write!(f, "The vendor {} is not supported.", v),
+            NoVendor(v) => write!(f, "The package management tool '{}' is not supported.", v),
             NoTask => write!(f, "The package management tool cannot perform the task."),
-            NotFoundTool => write!(
+            NoDetectVendor => write!(
                 f,
-                "No found package management tool, use `$UPT_TOOL` to specify one."
+                "No package management tool avaiable, use `$UPT_TOOL` to specify one."
             ),
             InvalidAction(v) => write!(f, "Invalid action '{}'.", v),
             InvalidArgs(v) => write!(f, "Invalid arguments.\n\n{}", v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 mod vendor;
 
 pub use error::UptError;
-pub use vendor::{detect_tool, init as init_vendor, Vendor};
+pub use vendor::{detect_vendor, init_vendor, Vendor};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@ macro_rules! vendors {
             },
         )+
     ) => {
-        pub fn init(name: &str) -> Result<$crate::Vendor, $crate::UptError> {
+        pub fn init_vendor(name: &str) -> Result<$crate::Vendor, $crate::UptError> {
             use $crate::action::must_from_str;
             match name {
                 $(
@@ -58,9 +58,9 @@ macro_rules! vendors {
     }
 }
 
-macro_rules! os_tools {
+macro_rules! os_vendors {
     ($($os:literal => $($tool:literal),+);+$(;)?) => {
-        pub fn detect_tool() -> std::result::Result<$crate::Vendor, $crate::UptError> {
+        pub fn detect_vendor() -> std::result::Result<$crate::Vendor, $crate::UptError> {
             let os = crate::utils::detect_os().unwrap_or_default();
             let tools: Vec<&str> = match os.as_str() {
                 $(
@@ -69,8 +69,8 @@ macro_rules! os_tools {
                 _ => vec!["apt", "dnf", "pacman"],
             };
             match $crate::utils::find_tool(&tools) {
-                Some(tool) => $crate::vendor::init(&tool),
-                None => Err(UptError::NotFoundTool),
+                Some(tool) => $crate::vendor::init_vendor(&tool),
+                None => Err(UptError::NoDetectVendor),
             }
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::Path;
 use std::process::{self, Command};
-use upt::{detect_tool, init_vendor, UptError, Vendor};
+use upt::{detect_vendor, init_vendor, UptError, Vendor};
 
 fn main() {
     match run() {
@@ -34,11 +34,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn create_cmd(vendor: &Vendor, args: &[String]) -> Result<String, UptError> {
-    let task = vendor.parse(args)?;
     let tool = match std::env::var("UPT_TOOL") {
         Ok(v) => init_vendor(&v)?,
-        Err(_) => detect_tool()?,
+        Err(_) => detect_vendor()?,
     };
+    let task = vendor.parse(args, tool.name())?;
     let cmd = tool.eval(&task)?;
     Ok(cmd)
 }


### PR DESCRIPTION
```diff
Usage: 
  upt install <pkg>                Install packages
  upt remove/uninstall <pkg>       Remove packages
  upt upgrade <pkg>                Upgrade packages
  upt search <pkg>                 Search for packages
  upt info/show <pkg>              Show package details
  upt update                       Update package indexes
  upt upgrade                      Upgrade all packages
  upt list                         List all installed packages

- Automatic answer yes to prompts: -y/--yes
+ Upt version: 0.5.0
+ Upt tool: apt
+ Confirm options: -y/--yes
```